### PR TITLE
Linux paths and smart playlist fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ If you set this option to `False` then the paths and the playlist file format wi
 
 If you plan on allowing other users/machines/software to access the playlist then you may find that the location embedded in the playlist file can only be accessed by the machine you created the playlist on. For example, `D:\My Music` won't be accessible by a NAS or a different computer. To solve this you can use `PATH_FIND` and `PATH_REPLACE` to swap out the paths within the playlists to ones which can be accessed. 
 
-> :warning: If you enable `USE_LINUX_PATHS` then you should be aware than all `\` in the path will have already been replaced with `/` __before__ `PATH_FIND` is considered. Therefore, you should ensure that `PATH_FIND` contains no `\` 
-
 `PATH_FIND` - the text to find within the path of a song
 
 `PATH_REPLACE` - the text to replace within the path of a song

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# itunes_playlist_exporter
+# iTunes Playlist exporter
 A script which connects to iTunes and exports all playlists in m3u format. It can also (optionally) adjust the paths of playlists to support remote drives (eg. on a NAS or a shared drive on another computer) and upload them to Plex.
 
 > :warning: **This script will delete playlists previously stored in Plex**: See the "Plex warning" section for more details.
@@ -9,17 +9,20 @@ This script has the following features:
 
 1. Export the playlists to any folder, including network drives
 2. Define playlists to be ignored based on their prefix
-3. Replace paths in a playlist with ones that can be accessed on by other users/machines/software (for example, repoint paths to a NAS)
-4. Delete existing playlists on Plex and upload new ones
-5. Command line options to prevent exporting of playlists and uploading of playlists (useful if trying to merge multiple playlists)
+3. Optionally write out the playlists using Linux file path convention and with Linux newline support
+4. Replace paths in a playlist with ones that can be accessed on by other users/machines/software (for example, repoint paths to a NAS)
+5. Delete existing playlists on Plex and upload new ones
+6. Command line options to prevent exporting of playlists and uploading of playlists (useful if trying to merge multiple playlists)
 
 ## Plex warning
 
 This script allows you to (optionally) upload your playlists to Plex.
 
-To enable this, this script treats iTunes as the primary store of playlists and mirrors the content to Plex. _**All Plex playlists solely associated with a music library (defined within the script) will be deleted and replaced**_.
+To enable this, this script treats iTunes as the primary store of playlists and mirrors the content to Plex. _**All non-smart Plex playlists solely associated with a music library (defined within the script) will be deleted and replaced**_.
 
-Playlists that contains content outside of the music library (eg. someone elses playlists or a playlist of video files) will not be removed. 
+The following playlist types will not be deleted:
+*  Playlists that contains content outside of the music library (eg. someone elses playlists or a playlist of video files)
+*  Smart playlists generated within Plex 
 
 > :warning: It is not recommended to use this script if you create and maintain music playlists within Plex.
 
@@ -30,7 +33,7 @@ In order to use this program you need the following:
 *   A computer running Microsoft Windows and iTunes
 *   Some music stored in iTunes using a DRM free format (eg. MP3 or AAC)
 *   One or more playlists for exporting
-*   Knowledge of running command line applications.
+*   Knowledge of running command line applications
 
 This program is not recommended for people who are not comfortable with the workings of Microsoft Windows and command line applications.
 
@@ -61,9 +64,22 @@ want these 'interim' ones being exported.
 
 For example, with a prefix of "x " then a playlist called "x Temporary" won't be exported.
 
+### USE_LINUX_PATHS
+
+This tells the script that the playlists will be accessed by a machine running Linux. One example of this would be if you intend on using the music software running on your NAS to access the playlists.
+
+If you set this option to `True` then then following things will happen:
+
+1.  All existing paths will have any `\` replaced with `/`
+2.  The created playlist will use Linux line-endings (`\n`) instead of DOS line-endings (`\r\n`)
+
+If you set this option to `False` then the paths and the playlist file format will be best suitable for Windows machines.
+
 ### PATH_FIND and PATH_REPLACE
 
 If you plan on allowing other users/machines/software to access the playlist then you may find that the location embedded in the playlist file can only be accessed by the machine you created the playlist on. For example, `D:\My Music` won't be accessible by a NAS or a different computer. To solve this you can use `PATH_FIND` and `PATH_REPLACE` to swap out the paths within the playlists to ones which can be accessed. 
+
+> :warning: If you enable `USE_LINUX_PATHS` then you should be aware than all `\` in the path will have already been replaced with `/` __before__ `PATH_FIND` is considered. Therefore, you should ensure that `PATH_FIND` contains no `\` 
 
 `PATH_FIND` - the text to find within the path of a song
 
@@ -89,7 +105,7 @@ The URL path to the Plex server and port number. This can start `http` or `https
 
 The number of the library that the playlists will be loaded into. Make sure this library exists, is set up for music and contains all the songs that you have in the playlists. To find your library, go into the Plex web client, hover the mouse over the library you want and look at the URL. It will end with `source=xx` where `xx` is the library ID.
 
-> :warning: **This script will delete any playlist that contains content solely from this LIBRARY_ID**
+> :warning: **This script will delete any (non-smart) playlists that contains content solely from this LIBRARY_ID**
 
 
 ### PLEX_PLAYLIST_LOCATION


### PR DESCRIPTION
Added support for converting Windows paths to Linux. This replaces \ with / and outputs the playlists with \n instead of \r\n.

Fixed a bug which meant that an additional blank line was added to the playlist content when no search and replaces were performed.

Smart playlists generated on Plex are now completely ignored and will never be scanned or deleted.